### PR TITLE
modified calculate.sh for regression testing, to do md5sum checking o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased - 2021-11-17
+https://jira.oicr.on.ca/browse/GP-2871 Making Regression Tests more robusts by adding md5sum checks to replace line counts
 ## 2.0.2 - 2020-06-10
 - Made cosmic parameter optional, it's not available for all organisms
 ## 2.0.1 - 2020-05-31

--- a/tests/calculate.sh
+++ b/tests/calculate.sh
@@ -5,6 +5,6 @@ set -o pipefail
 
 cd $1
 
-find . -regex '.*\.fusions.tsv$' -exec wc -l {} \;
-find . -regex '.*\.fusions.discarded.tsv$' -exec wc -l {} \;
-ls | sed 's/.*\.//' | sort | uniq -c
+find . -regex '.*\.fusions.tsv$' -exec md5sum {} \;
+find . -regex '.*\.fusions.discarded.tsv$' -exec md5sum {} \;
+find . -regex '.*\.fusions.pdf$' -exec sh -c "cat {} | grep -av Date | md5sum" \;

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -41,7 +41,10 @@
             "arriba.structuralVariants": null
         },
         "description": "ARRIBA workflow test",
-        "engineArguments": {},
+        "engineArguments": {
+          "write_to_cache": false,
+          "read_from_cache": false
+        },
         "id": "EPT105_RNAseqTest",
         "metadata": {
             "arriba.fusionDiscarded": {


### PR DESCRIPTION
-modified calculate.sh for regression testing, to do md5sum checking on whole or partial files
-replaced test results at /.mounts/labs/gsi/testdata/arriba/2.0/output_metrics/EPT105_RNAseqTest.metrics, for the one regression test