### PR TITLE
Adding additionalParameters option to arriba

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2024-12-19
+### Added
+additionalParameters - optional string for passing any non-exposed parameters to arriba
+
 ## [2.3.0] - 2024-06-25
 ### Added
 [GRD-797](https://jira.oicr.on.ca/browse/GRD-797)] - add vidarr labels to outputs (changes to medata only)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Parameter|Value|Default|Description
 Parameter|Value|Default|Description
 ---|---|---|---
 `runArriba.draw`|String|"$ARRIBA_ROOT/bin/draw_fusions.R"|path to arriba draw command
+`runArriba.additionalParameters`|String?|None|Any additional parameters we want to pass
 `runArriba.threads`|Int|8|Requested CPU threads
 `runArriba.jobMemory`|Int|64|Memory allocated for this job
 `runArriba.timeout`|Int|72|Hours before task timeout

--- a/arriba.wdl
+++ b/arriba.wdl
@@ -96,6 +96,7 @@ task runArriba {
     String domains 
     String blacklist 
     String? cosmic
+    String? additionalParameters
     String outputFileNamePrefix
     Int threads = 8
     Int jobMemory = 64
@@ -116,6 +117,7 @@ task runArriba {
     cosmic: "known fusions from cosmic, optional"
     blacklist: "List of fusions which are seen in normal tissue or artefacts"
     genome: "Path to loaded genome"
+    additionalParameters: "Any additional parameters we want to pass"
     threads: "Requested CPU threads"
     jobMemory: "Memory allocated for this job"
     timeout: "Hours before task timeout"
@@ -128,7 +130,7 @@ task runArriba {
       -x ~{inputBam} \
       -o ~{outputFileNamePrefix}.fusions.tsv -O ~{outputFileNamePrefix}.fusions.discarded.tsv \
       ~{"-d " + structuralVariants} ~{"-k " + cosmic} -t ~{knownfusions} \
-      -a ~{genome} -g ~{gencode} -b ~{blacklist} -p ~{domains}
+      -a ~{genome} -g ~{gencode} -b ~{blacklist} -p ~{domains} ~{additionalParameters}
 
       samtools index -@4 ~{inputBam}
 

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -27,6 +27,7 @@
             },
             "arriba.outputFileNamePrefix": "EPT105",
             "arriba.reference": "hg38",
+            "arriba.runArriba.additionalParameters": null,
             "arriba.runArriba.blacklist": null,
             "arriba.runArriba.cosmic": null,
             "arriba.runArriba.cytobands": null,


### PR DESCRIPTION
Investigating https://jira.oicr.on.ca/browse/GDI-3903, faulty data on chrY. It appears we can make the job pass if certain contigs (i.e. chrY) excluded. A more subtle approach would be modifying the blacklist, but pinpointing correct location is a time-consuming task.