### PR TITLE
Grd 1019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [GRD-1019](https://jira.oicr.on.ca/browse/GRD-1019)
 - Updated genomes to include hg38_noAlt
 
-## [2.4.2] - 2026-04-34
+## [2.4.2] - 2026-05-15
 ### Added
 - gencode parameter as a required workflow input to support gencode version selection via olive assay_confirguration.
 - resources for both gencode 44 and 31 versions, including noAlt genome

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [GRD-1019](https://jira.oicr.on.ca/browse/GRD-1019)
 - Updated genomes to include hg38_noAlt
 
+## [2.4.2] - 2026-04-34
+### Added
+- gencode parameter
+- resources for both gencode 44 and 31 versions
+### Changed
+- Updated the regression tests
+
+
 ## [2.4.1] - 2025-09-25
 ### Changed
 - [GRD-964](https://jira.oicr.on.ca/browse/GRD-964)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.4.2] - 2026-04-34
 ### Added
-- gencode parameter
-- resources for both gencode 44 and 31 versions
+- gencode parameter as a required workflow input to support gencode version selection via olive assay_confirguration.
+- resources for both gencode 44 and 31 versions, including noAlt genome
 ### Changed
 - Updated the regression tests
+- Replaced hardcoded gencode version in module with a dinamic lookup via nested Map
 
 
 ## [2.4.1] - 2025-09-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2026-02-06
+### Changed
+- [GRD-1019](https://jira.oicr.on.ca/browse/GRD-1019)
+- Updated genomes to include hg38_noAlt
+
 ## [2.4.1] - 2025-09-25
 ### Changed
 - [GRD-964](https://jira.oicr.on.ca/browse/GRD-964)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Parameter|Value|Description
 `indexBam`|File|Index for STAR Bam file
 `outputFileNamePrefix`|String|Prefix for filename
 `reference`|String|Reference id, i.e. hg38 (Currently the only one supported)
+`gencode`|String|Version of gencode
 
 
 #### Optional workflow parameters:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Output | Type | Description | Labels
  Run the program on bam output from STAR and detects RNA-seq fusion events
  
  ```
- 
        arriba 
        -x INPUT_BAMS 
        -o OUTPUT_PREFIX.fusions.tsv -O OUTPUT_PREFIX.fusions.discarded.tsv 

--- a/arriba.wdl
+++ b/arriba.wdl
@@ -115,6 +115,20 @@ workflow arriba {
        url: "https://www.r-project.org/"
      }
     ]
+    output_meta: {
+      fusionPredictions: {
+        description: "Fusion output tsv",
+        vidarr_label: "fusionPredictions"
+      },
+      fusionDiscarded: {
+        description: "Discarded fusion output tsv",
+        vidarr_label: "fusionDiscarded"
+      },
+      fusionFigure: {
+        description: "PDF rendering of candidate fusions",
+        vidarr_label: "fusionFigure"
+      }
+    }
   }
 }
 
@@ -186,22 +200,5 @@ task runArriba {
       File fusionPredictions        = "~{outputFileNamePrefix}.fusions.tsv"
       File fusionDiscarded          = "~{outputFileNamePrefix}.fusions.discarded.tsv"
       File fusionFigure             = "~{outputFileNamePrefix}.fusions.pdf"
-  }
-
-  meta {
-    output_meta: {
-    fusionPredictions: {
-        description: "Fusion output tsv",
-        vidarr_label: "fusionPredictions"
-    },
-    fusionDiscarded: {
-        description: "Discarded fusion output tsv",
-        vidarr_label: "fusionDiscarded"
-    },
-    fusionFigure: {
-        description: "PDF rendering of candidate fusions",
-        vidarr_label: "fusionFigure"
-    }
-}
   }
 }

--- a/arriba.wdl
+++ b/arriba.wdl
@@ -66,6 +66,28 @@ workflow arriba {
       "genome": "$HG38_NOALT_ROOT/hg38_noAlt.fa",
       "modules": "arriba/2.4.0 hg38-noalt/p12 samtools/1.16.1 rarriba/0.1 hg38-cosmic-fusion/v91 gencode/44"
       }
+    },
+    "grch38": {
+      "31": {
+      "blacklist": "$ARRIBA_ROOT/share/database/blacklist_hg38_GRCh38_v2.4.0.tsv.gz",
+      "cosmic": "$HG38_COSMIC_FUSION_ROOT/CosmicFusionExport.tsv",
+      "cytobands": "$ARRIBA_ROOT/share/database/cytobands_hg38_GRCh38_v2.4.0.tsv",
+      "domains": "$ARRIBA_ROOT/share/database/protein_domains_hg38_GRCh38_v2.4.0.gff3",
+      "gencode": "$GENCODE_ROOT/gencode.v31.annotation.gtf",
+      "knownFusion": "$ARRIBA_ROOT/share/database/known_fusions_hg38_GRCh38_v2.4.0.tsv.gz",
+      "genome": "$GRCH38_ROOT/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna",
+      "modules": "arriba/2.4.0 grch38/p15 samtools/1.16.1 rarriba/0.1 hg38-cosmic-fusion/v91 gencode/31"
+      },
+      "44": {
+      "blacklist": "$ARRIBA_ROOT/share/database/blacklist_hg38_GRCh38_v2.4.0.tsv.gz",
+      "cosmic": "$HG38_COSMIC_FUSION_ROOT/CosmicFusionExport.tsv",
+      "cytobands": "$ARRIBA_ROOT/share/database/cytobands_hg38_GRCh38_v2.4.0.tsv",
+      "domains": "$ARRIBA_ROOT/share/database/protein_domains_hg38_GRCh38_v2.4.0.gff3",
+      "gencode": "$GENCODE_ROOT/gencode.v44.annotation.gtf",
+      "knownFusion": "$ARRIBA_ROOT/share/database/known_fusions_hg38_GRCh38_v2.4.0.tsv.gz",
+      "genome": "$GRCH38_ROOT/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna",
+      "modules": "arriba/2.4.0 grch38/p15 samtools/1.16.1 rarriba/0.1 hg38-cosmic-fusion/v91 gencode/44"
+      }
     }
   }
 

--- a/arriba.wdl
+++ b/arriba.wdl
@@ -18,11 +18,23 @@ workflow arriba {
     File indexBam
     String outputFileNamePrefix
     String reference
+    String gencode
     File? structuralVariants
   }
 
-  Map[String,ArribaResources] resources = {
+  Map[String,Map[String,ArribaResources]] resources = {
     "hg38": {
+      "31": {
+      "blacklist": "$ARRIBA_ROOT/share/database/blacklist_hg38_GRCh38_v2.4.0.tsv.gz",
+      "cosmic": "$HG38_COSMIC_FUSION_ROOT/CosmicFusionExport.tsv",
+      "cytobands": "$ARRIBA_ROOT/share/database/cytobands_hg38_GRCh38_v2.4.0.tsv",
+      "domains": "$ARRIBA_ROOT/share/database/protein_domains_hg38_GRCh38_v2.4.0.gff3",
+      "gencode": "$GENCODE_ROOT/gencode.v31.annotation.gtf",
+      "knownFusion": "$ARRIBA_ROOT/share/database/known_fusions_hg38_GRCh38_v2.4.0.tsv.gz",
+      "genome": "$HG38_ROOT/hg38_random.fa",
+      "modules": "arriba/2.4.0 hg38/p12 samtools/1.16.1 rarriba/0.1 hg38-cosmic-fusion/v91 gencode/31"
+      },
+      "44": {
       "blacklist": "$ARRIBA_ROOT/share/database/blacklist_hg38_GRCh38_v2.4.0.tsv.gz",
       "cosmic": "$HG38_COSMIC_FUSION_ROOT/CosmicFusionExport.tsv",
       "cytobands": "$ARRIBA_ROOT/share/database/cytobands_hg38_GRCh38_v2.4.0.tsv",
@@ -31,8 +43,20 @@ workflow arriba {
       "knownFusion": "$ARRIBA_ROOT/share/database/known_fusions_hg38_GRCh38_v2.4.0.tsv.gz",
       "genome": "$HG38_ROOT/hg38_random.fa",
       "modules": "arriba/2.4.0 hg38/p12 samtools/1.16.1 rarriba/0.1 hg38-cosmic-fusion/v91 gencode/44"
+      }
     },
     "hg38_noAlt": {
+      "31": {
+      "blacklist": "$ARRIBA_ROOT/share/database/blacklist_hg38_GRCh38_v2.4.0.tsv.gz",
+      "cosmic": "$HG38_COSMIC_FUSION_ROOT/CosmicFusionExport.tsv",
+      "cytobands": "$ARRIBA_ROOT/share/database/cytobands_hg38_GRCh38_v2.4.0.tsv",
+      "domains": "$ARRIBA_ROOT/share/database/protein_domains_hg38_GRCh38_v2.4.0.gff3",
+      "gencode": "$GENCODE_ROOT/gencode.v31.annotation.gtf",
+      "knownFusion": "$ARRIBA_ROOT/share/database/known_fusions_hg38_GRCh38_v2.4.0.tsv.gz",
+      "genome": "$HG38_NOALT_ROOT/hg38_noAlt.fa",
+      "modules": "arriba/2.4.0 hg38-noalt/p12 samtools/1.16.1 rarriba/0.1 hg38-cosmic-fusion/v91 gencode/31"
+      },
+      "44": {
       "blacklist": "$ARRIBA_ROOT/share/database/blacklist_hg38_GRCh38_v2.4.0.tsv.gz",
       "cosmic": "$HG38_COSMIC_FUSION_ROOT/CosmicFusionExport.tsv",
       "cytobands": "$ARRIBA_ROOT/share/database/cytobands_hg38_GRCh38_v2.4.0.tsv",
@@ -41,6 +65,7 @@ workflow arriba {
       "knownFusion": "$ARRIBA_ROOT/share/database/known_fusions_hg38_GRCh38_v2.4.0.tsv.gz",
       "genome": "$HG38_NOALT_ROOT/hg38_noAlt.fa",
       "modules": "arriba/2.4.0 hg38-noalt/p12 samtools/1.16.1 rarriba/0.1 hg38-cosmic-fusion/v91 gencode/44"
+      }
     }
   }
 
@@ -50,6 +75,7 @@ workflow arriba {
     indexBam: "Index for STAR Bam file"
     outputFileNamePrefix: "Prefix for filename"
     reference: "Reference id, i.e. hg38 (Currently the only one supported)"
+    gencode: "Version of gencode"
     structuralVariants: "path to structural variants for sample"
   }
 
@@ -57,14 +83,14 @@ workflow arriba {
     input:
     inputBam = inputBam,
     indexBam = indexBam,
-    modules = resources[reference].modules,
-    gencode = resources[reference].gencode,
-    genome = resources[reference].genome,
-    knownfusions = resources[reference].knownFusion,
-    cytobands = resources[reference].cytobands,
-    cosmic = resources[reference].cosmic,
-    domains = resources[reference].domains,
-    blacklist = resources[reference].blacklist,
+    modules = resources[reference][gencode].modules,
+    gencode = resources[reference][gencode].gencode,
+    genome = resources[reference][gencode].genome,
+    knownfusions = resources[reference][gencode].knownFusion,
+    cytobands = resources[reference][gencode].cytobands,
+    cosmic = resources[reference][gencode].cosmic,
+    domains = resources[reference][gencode].domains,
+    blacklist = resources[reference][gencode].blacklist,
     outputFileNamePrefix = outputFileNamePrefix,
     structuralVariants = structuralVariants
   }

--- a/arriba.wdl
+++ b/arriba.wdl
@@ -31,6 +31,16 @@ workflow arriba {
       "knownFusion": "$ARRIBA_ROOT/share/database/known_fusions_hg38_GRCh38_v2.4.0.tsv.gz",
       "genome": "$HG38_ROOT/hg38_random.fa",
       "modules": "arriba/2.4.0 hg38/p12 samtools/1.16.1 rarriba/0.1 hg38-cosmic-fusion/v91 gencode/44"
+    },
+    "hg38_noAlt": {
+      "blacklist": "$ARRIBA_ROOT/share/database/blacklist_hg38_GRCh38_v2.4.0.tsv.gz",
+      "cosmic": "$HG38_COSMIC_FUSION_ROOT/CosmicFusionExport.tsv",
+      "cytobands": "$ARRIBA_ROOT/share/database/cytobands_hg38_GRCh38_v2.4.0.tsv",
+      "domains": "$ARRIBA_ROOT/share/database/protein_domains_hg38_GRCh38_v2.4.0.gff3",
+      "gencode": "$GENCODE_ROOT/gencode.v44.annotation.gtf",
+      "knownFusion": "$ARRIBA_ROOT/share/database/known_fusions_hg38_GRCh38_v2.4.0.tsv.gz",
+      "genome": "$HG38_NOALT_ROOT/hg38_noAlt.fa",
+      "modules": "arriba/2.4.0 hg38-noalt/p12 samtools/1.16.1 rarriba/0.1 hg38-cosmic-fusion/v91 gencode/44"
     }
   }
 

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -1,4 +1,89 @@
 [
+     {
+        "arguments": {
+            "arriba.indexBam": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/arriba/test_inputs/test_1.Aligned.sortedByCoord.out.bai",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "arriba.inputBam": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/arriba/test_inputs/test_1.Aligned.sortedByCoord.out.bam",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "arriba.outputFileNamePrefix": "test_1_g31",
+            "arriba.reference": "hg38",
+            "arriba.gencode": "31",
+            "arriba.runArriba.additionalParameters": null,
+            "arriba.runArriba.blacklist": null,
+            "arriba.runArriba.cosmic": null,
+            "arriba.runArriba.cytobands": null,
+            "arriba.runArriba.domains": null,
+            "arriba.runArriba.draw": null,
+            "arriba.runArriba.gencode": null,
+            "arriba.runArriba.genome": null,
+            "arriba.runArriba.jobMemory": null,
+            "arriba.runArriba.knownfusions": null,
+            "arriba.runArriba.modules": null,
+            "arriba.runArriba.threads": null,
+            "arriba.runArriba.timeout": null,
+            "arriba.structuralVariants": null
+        },
+        "description": "ARRIBA workflow test with gencode 31 annotations",
+        "engineArguments": {
+          "write_to_cache": false,
+          "read_from_cache": false
+        },
+        "id": "EPT_RNAseqTest",
+        "metadata": {
+            "arriba.fusionDiscarded": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "arriba.fusionFigure": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "arriba.fusionsPredictions": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            }
+        },
+        "validators": [
+            {
+                "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
+                "metrics_compare": "@CHECKOUT@/tests/compare.sh",
+                "output_metrics": "/.mounts/labs/gsi/testdata/arriba/2.4/output_metrics/workflow_test_01.metrics",
+                "type": "script"
+            }
+        ]
+    },
     {
         "arguments": {
             "arriba.indexBam": {
@@ -25,8 +110,9 @@
                 },
                 "type": "EXTERNAL"
             },
-            "arriba.outputFileNamePrefix": "test_1",
+            "arriba.outputFileNamePrefix": "test_1_g44",
             "arriba.reference": "hg38",
+            "arriba.gencode": "44",
             "arriba.runArriba.additionalParameters": null,
             "arriba.runArriba.blacklist": null,
             "arriba.runArriba.cosmic": null,
@@ -42,7 +128,7 @@
             "arriba.runArriba.timeout": null,
             "arriba.structuralVariants": null
         },
-        "description": "ARRIBA workflow test",
+        "description": "ARRIBA workflow test with gencode 44 annotations",
         "engineArguments": {
           "write_to_cache": false,
           "read_from_cache": false
@@ -111,6 +197,7 @@
             },
             "arriba.outputFileNamePrefix": "test_noAlt",
             "arriba.reference": "hg38_noAlt",
+            "arriba.gencode": "44",
             "arriba.runArriba.additionalParameters": null,
             "arriba.runArriba.blacklist": null,
             "arriba.runArriba.cosmic": null,

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -78,7 +78,91 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/arriba/2.4/output_metrics/workflow_test_01.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/arriba/2.5/output_metrics/workflow_test_01.metrics",
+                "type": "script"
+            }
+        ]
+    },
+    {
+        "arguments": {
+            "arriba.indexBam": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/arriba/test_inputs/test_1.Aligned.sortedByCoord.out.bai",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "arriba.inputBam": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/arriba/test_inputs/test_1.Aligned.sortedByCoord.out.bam",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "arriba.outputFileNamePrefix": "test_noAlt",
+            "arriba.reference": "hg38_noAlt",
+            "arriba.runArriba.additionalParameters": null,
+            "arriba.runArriba.blacklist": null,
+            "arriba.runArriba.cosmic": null,
+            "arriba.runArriba.cytobands": null,
+            "arriba.runArriba.domains": null,
+            "arriba.runArriba.draw": null,
+            "arriba.runArriba.gencode": null,
+            "arriba.runArriba.genome": null,
+            "arriba.runArriba.jobMemory": null,
+            "arriba.runArriba.knownfusions": null,
+            "arriba.runArriba.modules": null,
+            "arriba.runArriba.threads": null,
+            "arriba.runArriba.timeout": null,
+            "arriba.structuralVariants": null
+        },
+        "description": "ARRIBA workflow test - noAlt",
+        "engineArguments": {
+          "write_to_cache": false,
+          "read_from_cache": false
+        },
+        "id": "noAlt_RNAseqTest",
+        "metadata": {
+            "arriba.fusionDiscarded": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "arriba.fusionFigure": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "arriba.fusionsPredictions": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            }
+        },
+        "validators": [
+            {
+                "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
+                "metrics_compare": "@CHECKOUT@/tests/compare.sh",
+                "output_metrics": "/.mounts/labs/gsi/testdata/arriba/2.5/output_metrics/workflow_test_02.metrics",
                 "type": "script"
             }
         ]

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -3,7 +3,7 @@
         "arguments": {
             "arriba.indexBam": {
                 "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/arriba/test_inputs/test_1.Aligned.sortedByCoord.out.bai",
+                    "configuration": "/.mounts/labs/gsi/testdata/arriba/test_inputs/EPT_Test.Aligned.sortedByCoord.out.bai",
                     "externalIds": [
                         {
                             "id": "TEST",
@@ -15,7 +15,7 @@
             },
             "arriba.inputBam": {
                 "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/arriba/test_inputs/test_1.Aligned.sortedByCoord.out.bam",
+                    "configuration": "/.mounts/labs/gsi/testdata/arriba/test_inputs/EPT_Test.Aligned.sortedByCoord.out.bam",
                     "externalIds": [
                         {
                             "id": "TEST",

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -25,7 +25,7 @@
                 },
                 "type": "EXTERNAL"
             },
-            "arriba.outputFileNamePrefix": "test_1_g31",
+            "arriba.outputFileNamePrefix": "test_1",
             "arriba.reference": "hg38",
             "arriba.gencode": "31",
             "arriba.runArriba.additionalParameters": null,
@@ -110,7 +110,7 @@
                 },
                 "type": "EXTERNAL"
             },
-            "arriba.outputFileNamePrefix": "test_1_g44",
+            "arriba.outputFileNamePrefix": "test_1",
             "arriba.reference": "hg38",
             "arriba.gencode": "44",
             "arriba.runArriba.additionalParameters": null,

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -48,12 +48,12 @@
           "write_to_cache": false,
           "read_from_cache": false
         },
-        "id": "EPT_RNAseqTest",
+        "id": "EPT_RNAseqTest_g31",
         "metadata": {
             "arriba.fusionDiscarded": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_g31_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -61,7 +61,7 @@
             "arriba.fusionFigure": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_g31_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -69,7 +69,7 @@
             "arriba.fusionsPredictions": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_g31_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -133,12 +133,12 @@
           "write_to_cache": false,
           "read_from_cache": false
         },
-        "id": "EPT_RNAseqTest",
+        "id": "EPT_RNAseqTest_g44",
         "metadata": {
             "arriba.fusionDiscarded": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_g44_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -146,7 +146,7 @@
             "arriba.fusionFigure": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_g44_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -154,7 +154,7 @@
             "arriba.fusionsPredictions": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_g44_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -223,7 +223,7 @@
             "arriba.fusionDiscarded": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_noAlt_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -231,7 +231,7 @@
             "arriba.fusionFigure": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_noAlt_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -239,7 +239,7 @@
             "arriba.fusionsPredictions": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_arriba_test_RNAseqTest_noAlt_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -3,7 +3,7 @@
         "arguments": {
             "arriba.indexBam": {
                 "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/arriba/test_inputs/EPT_Test.Aligned.sortedByCoord.out.bai",
+                    "configuration": "/.mounts/labs/gsi/testdata/arriba/test_inputs/test_1.Aligned.sortedByCoord.out.bai",
                     "externalIds": [
                         {
                             "id": "TEST",
@@ -15,7 +15,7 @@
             },
             "arriba.inputBam": {
                 "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/arriba/test_inputs/EPT_Test.Aligned.sortedByCoord.out.bam",
+                    "configuration": "/.mounts/labs/gsi/testdata/arriba/test_inputs/test_1.Aligned.sortedByCoord.out.bam",
                     "externalIds": [
                         {
                             "id": "TEST",
@@ -48,7 +48,7 @@
           "write_to_cache": false,
           "read_from_cache": false
         },
-        "id": "EPT_RNAseqTest_g31",
+        "id": "RNAseqTest_g31",
         "metadata": {
             "arriba.fusionDiscarded": {
                 "contents": [
@@ -79,7 +79,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/arriba/2.4/output_metrics/workflow_test_01.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/arriba/2.4/output_metrics/workflow_test_01_g31.metrics",
                 "type": "script"
             }
         ]
@@ -133,7 +133,7 @@
           "write_to_cache": false,
           "read_from_cache": false
         },
-        "id": "EPT_RNAseqTest_g44",
+        "id": "RNAseqTest_g44",
         "metadata": {
             "arriba.fusionDiscarded": {
                 "contents": [


### PR DESCRIPTION
This update is reconciled with Monica's and Aditi's work - v.2.4.2 includes both forking on gencode feature and noAlt genome support. I suppose this can replace our production workflow and this will be the only version required as the work done earlier allows us to read gencode value from assay_info and launch workflows with any combination of gencode/reference.